### PR TITLE
fix(get-commits): correct how commitPaths  gets translated into args

### DIFF
--- a/lib/get-commits.js
+++ b/lib/get-commits.js
@@ -9,18 +9,17 @@ const debug = require('debug')('semantic-release:get-commits');
  *
  * @return {Promise<Array<Object>>} The list of commits on the branch `branch` since the last release.
  */
-module.exports = async ({cwd, env, lastRelease: {gitHead}, logger, options: {commitPaths = []} = {}}) => {
+module.exports = async ({cwd, env, lastRelease: {gitHead}, logger, options: {commitPaths} = {}}) => {
   if (gitHead) {
     debug('Use gitHead: %s', gitHead);
   } else {
     logger.log('No previous release found, retrieving all commits');
   }
 
-  let paths;
+  let pathArgs = [];
   if (Array.isArray(commitPaths) && commitPaths.length > 0) {
-    paths = commitPaths.join(' ');
-    logger.log('Commits are being filtered by the commitPaths property: %s', paths);
-    paths = ' -- ' + paths;
+    logger.log('Commits are being filtered by the commitPaths property: %s', ...commitPaths);
+    pathArgs = ['--', ...commitPaths];
   }
 
   Object.assign(gitLogParser.fields, {
@@ -33,7 +32,7 @@ module.exports = async ({cwd, env, lastRelease: {gitHead}, logger, options: {com
   const commits = (await getStream.array(
     gitLogParser.parse(
       {
-        _: [`${gitHead ? gitHead + '..' : ''}HEAD${paths ? paths : ''}`],
+        _: [`${gitHead ? gitHead + '..' : ''}HEAD`, ...pathArgs],
       },
       {cwd, env: {...process.env, ...env}}
     )

--- a/test/get-commits.test.js
+++ b/test/get-commits.test.js
@@ -106,17 +106,44 @@ test('Get all commits under a path when there is no last release ', async t => {
   // Create a git repository, set the current working directory at the root of the repo
   const {cwd} = await gitRepo();
   // Add commits to the master branch
-  const commits = await gitCommits(['First', 'Second'], {cwd});
-  console.log(commits.length);
+  await gitCommits(['First', 'Second'], {cwd});
   // Retrieve the commits with the commits module
   const result = await getCommits({
     cwd,
     lastRelease: {},
     logger: t.context.logger,
-    options: {commitPaths: ['test/*', 'test2/*']},
+    options: {commitPaths: ['i/dont/exist/*', 'still/dont/exist/*']},
   });
 
   // Verify the commits created and retrieved by the module are identical
   t.is(result.length, 0);
-  // T.deepEqual(result, commits);
+  t.deepEqual(result, []);
 });
+
+// Test('Get all commits using commitPaths option ', async t => {
+//   /**
+//    * FIXME: to be able to properly test this we will need to mock the git
+//    * repository differently so that we can add files to a commit during test
+//    * so that we have a consistent set of commits with file names that fall
+//    * under a path. Until then we are just verifying that we get a different
+//    * result than what we would expect if we were to not filter by path.
+//    * */
+
+//   // Create a git repository, set the current working directory at the root of the repo
+//   const {cwd} = await gitRepo();
+//   // Add commits to the master branch
+//   const commits = await gitCommits(['First', 'Second'], {cwd});
+//   // Retrieve the commits with the commits module
+//   const result = await getCommits({
+//     cwd,
+//     lastRelease: {},
+//     logger: t.context.logger,
+//     options: {commitPaths: [`*`]},
+//   });
+
+//   console.log('commits:', commits);
+//   // Verify the commits created and retrieved by the module are identical
+//   console.log('result:', result);
+//   t.is(result.length, commits.length);
+//   t.deepEqual(result, commits);
+// });


### PR DESCRIPTION
* Testing needs to be improved, currently filtering works in a real repo but in the test temp repo it is not working.