### PR TITLE
feat: adds a skipTag option to turn off git tagging

### DIFF
--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -15,4 +15,8 @@
 - [Publishing maintenance releases](maintenance-releases.md)
 - [Publishing pre-releases](pre-releases.md)
 
+## Utility
+- [Get expected next version](expected-next-version.md)
+
+
 ## Package managers and languages

--- a/docs/recipes/expected-next-version.md
+++ b/docs/recipes/expected-next-version.md
@@ -1,0 +1,41 @@
+# Getting the expected next version
+
+There are some situations where you will need the next version prior to running semantic-release, some examples are languages that require the build number at build time. Since semantic-release is focused on releasing your built bits not building them you will need to run semantic-release twice. The following may help you setup this workflow within your solution.
+
+## Example use case
+In this example we are building a docker image that must include a file in the docker image that includes the build number. This is created by a custom semantic-release plugin call application-info. But you could use the exec plugin to accomplish a similar task of writing to a file or some other destination.
+
+Create your standard release.config.js
+
+```JavaScript
+// release.config.js
+module.exports = {
+  plugins: [
+    '@semantic-release/commit-analyzer',
+    '@semantic-release/release-notes-generator',
+    [
+      'semantic-release-docker',
+      {
+        name: `my-cool-docker-app`,
+      },
+    ],
+  ],
+};
+```
+> this is just an example config you may need something more complex in your scenario
+
+Create a pre-release.config.js that will be run before running semantic-release that extends your base release config overriding the the skipTag property and plugins property to only include the plugins needed in the pre-release stage. 
+
+```JavaScript
+// pre-release.config.js
+// npx semantic-release --extends=./pre-release.config.js
+
+const baseReleaseConfig = require('./release.config.js');
+
+module.exports = {
+  ...baseReleaseConfig,
+  skipTag: true,
+  plugins: ['@semantic-release/commit-analyzer', './release-scripts/application-info'],
+};
+```
+In your CI solution you should run `npx semantic-release --extends=./pre-release.config.js` prior to building your application to perform any tasks that are required as part of the build and to include the next version number.

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -142,6 +142,13 @@ The objective of the dry-run mode is to get a preview of the pending release. Dr
 
 **Note**: The Dry-run mode verifies the repository push permission, even though nothing will be pushed. The verification is done to help user to figure out potential configuration issues.
 
+### skipTag
+Type: `Boolean`<br>
+Default: `false`
+CLI arguments: `--skip-tag`
+
+Prevent tagging of the git commit on release
+
 ### ci
 
 Type: `Boolean`<br>

--- a/index.js
+++ b/index.js
@@ -109,8 +109,8 @@ async function run(context, plugins) {
       const commits = await getCommits({...context, lastRelease, nextRelease});
       nextRelease.notes = await plugins.generateNotes({...context, commits, lastRelease, nextRelease});
 
-      if (options.dryRun) {
-        logger.warn(`Skip ${nextRelease.gitTag} tag creation in dry-run mode`);
+      if (options.dryRun || options.skipTag) {
+        logger.warn(`Skip ${nextRelease.gitTag} tag creation in dry-run / skip-tag mode`);
       } else {
         await addNote({channels: [...currentRelease.channels, nextRelease.channel]}, nextRelease.gitHead, {cwd, env});
         await push(options.repositoryUrl, {cwd, env});
@@ -184,8 +184,8 @@ async function run(context, plugins) {
 
   await plugins.prepare(context);
 
-  if (options.dryRun) {
-    logger.warn(`Skip ${nextRelease.gitTag} tag creation in dry-run mode`);
+  if (options.dryRun || options.skipTag) {
+    logger.warn(`Skip ${nextRelease.gitTag} tag creation in dry-run / skip-tag mode`);
   } else {
     // Create the tag before calling the publish plugins as some require the tag to exists
     await tag(nextRelease.gitTag, nextRelease.gitHead, {cwd, env});


### PR DESCRIPTION
# Adds the ability to skip creating the git tag 

This will support a workflow in situations where a the version is needed prior to creating a release. Common languages that require this are Java, C# (.net), C++. 

Another scenario is when publishing docker images that a version number needs to be present inside the docker image.

This relates to the following PR's/Issues:
* https://github.com/semantic-release/semantic-release/pull/1076
* https://github.com/semantic-release/semantic-release/issues/753