### PR TITLE
docs(recipes): fixed typo

### DIFF
--- a/docs/recipes/nx-monorepo.md
+++ b/docs/recipes/nx-monorepo.md
@@ -50,7 +50,7 @@ module.exports = {
         changelogFile: `${appPath}/CHANGELOG.md`,
       },
     ],
-    'semantic-release/npm',
+    '@semantic-release/npm',
     [
       '@semantic-release/git',
       {


### PR DESCRIPTION
Added missing @ . Otherwise publishing will fail with `Cannot find module 'semantic-release/npm`.